### PR TITLE
Add start and stop commands for bot management

### DIFF
--- a/mh_boss_timer.py
+++ b/mh_boss_timer.py
@@ -492,7 +492,6 @@ async def removeboss(interaction: discord.Interaction, name: str):
         )
 
 
-# Optional: manual "kill" command (backup)
 @bot.tree.command(description="Mark a boss as killed (uses default respawn).")
 @app_commands.describe(name="Exact boss name")
 async def kill(interaction: discord.Interaction, name: str):
@@ -503,6 +502,44 @@ async def kill(interaction: discord.Interaction, name: str):
         f"{'✅' if ok else '❌'} {name} {'timer reset.' if ok else 'not found.'}",
         ephemeral=True,
     )
+
+
+@bot.tree.command(description="Initialize or ensure bot is active in this server (admin).")
+@app_commands.checks.has_permissions(administrator=True)
+async def startbot(interaction: discord.Interaction):
+    try:
+        await bot.tree.sync(guild=interaction.guild)
+        if not update_dashboards.is_running():
+            update_dashboards.start()
+        await interaction.response.send_message(
+            "✅ Bot is active and commands are synced.", ephemeral=True
+        )
+    except Exception as e:
+        await interaction.response.send_message(
+            f"❌ Failed to initialize bot: {e}", ephemeral=True
+        )
+
+
+@bot.tree.command(description="Stop the bot (admin).")
+@app_commands.checks.has_permissions(administrator=True)
+async def stopbot(interaction: discord.Interaction):
+    try:
+        # Save all data before stopping
+        await save_json(BOSSES_FILE, bosses_master)
+        await save_json(CHANNEL_DATA_FILE, channel_data)
+        await save_json(DASHBOARDS_FILE, dashboards)
+        # Stop the update task
+        if update_dashboards.is_running():
+            update_dashboards.stop()
+        await interaction.response.send_message(
+            "✅ Bot is shutting down.", ephemeral=True
+        )
+        await bot.close()
+        os._exit(0)
+    except Exception as e:
+        await interaction.response.send_message(
+            f"❌ Failed to stop bot: {e}", ephemeral=True
+        )
 
 
 # ----------------------------


### PR DESCRIPTION
To add Discord slash commands for initiating (starting) or terminating (stopping) the bot, we need to implement `/startbot` and `/stopbot`commands. These should be restricted to administrators to prevent misuse. The bot is already started when the script runs (`bot.run(TOKEN)`), so `/startbot` could be used to reinitialize or ensure the bot is active in a specific server, while `/stopbot` should gracefully shut down the bot. Since `bot.run` is a blocking call, stopping the bot requires closing the Discord connection and exiting the process.

### Implementation Plan

1. **Add** `/startbot` **Command**:

- Check if the bot is already synced and active in the guild.
- Ensure slash commands are synced.
- Respond with confirmation.
- Restrict to administrators with @app_commands.checks.has_permissions(administrator=True).


2. **Add** `/stopbot` **Command**:

- Stop the dashboard update task.
- Close the Discord connection using bot.close().
- Exit the process with os._exit(0) (since bot.run blocks).
- Restrict to administrators.
- Save all JSON files before exiting to prevent data loss.


3. **Update Permissions**:

- Ensure both commands require admin permissions.
- Provide clear feedback for unauthorized users.


4. **Artifact Update**:

- Modify the existing script (artifact_id: `550e8400-e29b-41d4-a716-446655440000`).
- Add the new commands in the "Slash Commands" section.
- Ensure all existing functionality remains unchanged.

### Changes to the Script

- In the "Slash Commands" section, add `/startbot` and `/stopbot` after the existing commands.
- Import `os` explicitly for `os._exit` (already imported, so no change needed).
- Ensure `update_dashboards` task is stopped before shutdown.